### PR TITLE
Fix 2D Platformer header link

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
 						<div class="col-4 col-6-medium col-12-small">
 							<article class="box style2">
 								<a href="https://sites.google.com/umn.edu/csci-5611-final/home" target="_blank" class="image featured"><img src="images/projectFinal.png" alt="" /></a>
-								<h3><a href="https://sites.google.com/umn.edu/csci-5611-final/home" target="_blank" 2D Platformer</a></h3>
+                                                                <h3><a href="https://sites.google.com/umn.edu/csci-5611-final/home" target="_blank">2D Platformer</a></h3>
 								<p>Applied PCG, a genetic algorithm, pathfinding, and sprite animation.</p>
 							</article>
 						</div>


### PR DESCRIPTION
## Summary
- fix formatting for "2D Platformer" header link

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e6fcd788883268e155f8c26b50099